### PR TITLE
Convert Express-style path params to OpenAPI format

### DIFF
--- a/.changeset/openapi-path-param-syntax.md
+++ b/.changeset/openapi-path-param-syntax.md
@@ -1,0 +1,9 @@
+---
+"@protocols-fyi/clover": patch
+---
+
+Fix OpenAPI path parameter syntax in generated specs
+
+- Convert Express-style path parameters (`:param`) to OpenAPI-standard syntax (`{param}`) in `openAPIPathsObject`
+- Add `toOpenAPIPath()` utility function for path conversion
+- Fixes compatibility with OpenAPI validators and documentation tools (e.g., Mintlify) that expect `{param}` format

--- a/packages/clover/src/server.test.ts
+++ b/packages/clover/src/server.test.ts
@@ -607,6 +607,23 @@ describe("makeRequestHandler", () => {
         },
       });
     });
+
+    it("should convert Express-style path params to OpenAPI format", () => {
+      const { openAPIPathsObject } = makeRequestHandler({
+        input: z.object({ userId: z.string(), postId: z.string() }),
+        output: z.object({ post: z.string() }),
+        method: "GET",
+        path: "/api/users/:userId/posts/:postId",
+        run: async ({ sendOutput }) => {
+          return sendOutput({ post: "test" });
+        },
+      });
+
+      // Path should use {param} syntax, not :param
+      expect(Object.keys(openAPIPathsObject)).toEqual([
+        "/api/users/{userId}/posts/{postId}",
+      ]);
+    });
   });
 
   it("should return 400 for missing required fields", async () => {

--- a/packages/clover/src/server.ts
+++ b/packages/clover/src/server.ts
@@ -8,6 +8,7 @@ import {
   getKeysFromPathPattern,
   getParamsFromPath,
   httpMethodSupportsRequestBody,
+  toOpenAPIPath,
 } from "./utils";
 import { getLogger, formatLogPayload } from "./logger";
 
@@ -225,7 +226,7 @@ export const makeRequestHandler = <
   };
 
   const openAPIPath: oas31.PathsObject = {
-    [props.path]: openAPIPathItem,
+    [toOpenAPIPath(props.path)]: openAPIPathItem,
   };
 
   const handler = async (request: Request) => {

--- a/packages/clover/src/utils.test.ts
+++ b/packages/clover/src/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getKeysFromPathPattern, getParamsFromPath } from "./utils";
+import {
+  getKeysFromPathPattern,
+  getParamsFromPath,
+  toOpenAPIPath,
+} from "./utils";
 
 describe("utils", () => {
   describe("getKeysFromPathPattern", () => {
@@ -25,6 +29,28 @@ describe("utils", () => {
       const path = "/api/users/123";
       const params = getParamsFromPath(pattern, path);
       expect(params).toEqual({ id: "123" });
+    });
+  });
+
+  describe("toOpenAPIPath", () => {
+    it("should convert single parameter", () => {
+      expect(toOpenAPIPath("/api/users/:id")).toBe("/api/users/{id}");
+    });
+
+    it("should convert multiple parameters", () => {
+      expect(toOpenAPIPath("/api/users/:userId/posts/:postId")).toBe(
+        "/api/users/{userId}/posts/{postId}"
+      );
+    });
+
+    it("should handle paths without parameters", () => {
+      expect(toOpenAPIPath("/api/users")).toBe("/api/users");
+    });
+
+    it("should handle parameter at end of path", () => {
+      expect(toOpenAPIPath("/api/v1/catalog/:collection/:scenario")).toBe(
+        "/api/v1/catalog/{collection}/{scenario}"
+      );
     });
   });
 });

--- a/packages/clover/src/utils.ts
+++ b/packages/clover/src/utils.ts
@@ -51,3 +51,11 @@ export type PathParamNames<
   : Path extends `${string}:${infer Name}`
   ? Name | Acc
   : Acc;
+
+/**
+ * Convert Express-style path parameters to OpenAPI-style.
+ * e.g., "/api/v1/users/:id/posts/:postId" → "/api/v1/users/{id}/posts/{postId}"
+ */
+export const toOpenAPIPath = (path: string): string => {
+  return path.replace(/:([^/]+)/g, "{$1}");
+};


### PR DESCRIPTION
## Summary

Fixes a bug where `openAPIPathsObject` used Express-style path parameters (`:param`) instead of OpenAPI-standard syntax (`{param}`).

**Before:** `/api/users/:userId/posts/:postId`
**After:** `/api/users/{userId}/posts/{postId}`

## Changes

- Added `toOpenAPIPath()` utility function in `utils.ts`
- Updated `server.ts` to use this function when constructing `openAPIPath`
- Added tests for the new utility and the path conversion behavior

## Test Plan

- [x] Added unit tests for `toOpenAPIPath()` covering single params, multiple params, and no params
- [x] Added integration test in `server.test.ts` verifying `openAPIPathsObject` uses `{param}` format
- [x] All 41 tests pass