### PR TITLE
fix: patch brace-expansion ReDoS vulnerability

### DIFF
--- a/.changeset/lazy-lizards-stand.md
+++ b/.changeset/lazy-lizards-stand.md
@@ -1,0 +1,5 @@
+---
+"@protocols-fyi/clover": patch
+---
+
+Fix brace-expansion ReDoS vulnerability (CVE-2025-5889) via pnpm overrides

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
     "turbo": "^2.3.3"
   },
   "packageManager": "pnpm@9.4.0",
-  "name": "cardboard"
+  "name": "cardboard",
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@^1": "^1.1.12",
+      "brace-expansion@^2": "^2.0.2"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@^1: ^1.1.12
+  brace-expansion@^2: ^2.0.2
+
 importers:
 
   .:
@@ -1651,11 +1655,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5291,12 +5295,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -6985,11 +6989,11 @@ snapshots:
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Adds pnpm overrides to force patched versions of `brace-expansion`
- Fixes CVE-2025-5889 (low severity ReDoS vulnerability)

## Details
The vulnerability was in transitive dependencies:
- `brace-expansion@1.1.11` via `eslint` → `minimatch@3.1.2`
- `brace-expansion@2.0.1` via `eslint-config-next` → `@typescript-eslint/*` → `minimatch@9.0.5`

Overrides force:
- `brace-expansion@^1` → `^1.1.12`
- `brace-expansion@^2` → `^2.0.2`

## Test plan
- [x] `pnpm audit` returns no vulnerabilities